### PR TITLE
Fix strpos and update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "type": "library",
     "require": {
-        "php": ">=7.2.0"
+        "php": ">=7.4"
     },
     "require-dev": {
         "mockery/mockery": "^1.3",

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -341,7 +341,7 @@ class Parser implements ParserInterface
                     $toCopyStartMax = $toSegmentEnd - $copyLen;
 
                     while ($toCopyStart <= $toCopyStartMax) {
-                        $fromCopyStart = strpos(mb_substr($fromText, $fromSegmentStart, $fromSegmentLen), substr($toText, $toCopyStart, $copyLen));
+                        $fromCopyStart = mb_strpos(mb_substr($fromText, $fromSegmentStart, $fromSegmentLen), substr($toText, $toCopyStart, $copyLen));
 
                         if ($fromCopyStart !== false) {
                             $fromCopyStart += $fromSegmentStart;
@@ -361,7 +361,7 @@ class Parser implements ParserInterface
                     $fromCopyStartMax = $fromSegmentEnd - $copyLen;
 
                     while ($fromCopyStart <= $fromCopyStartMax) {
-                        $toCopyStart = strpos(mb_substr($toText, $toSegmentStart, $toSegmentLen), substr($fromText, $fromCopyStart, $copyLen));
+                        $toCopyStart = mb_strpos(mb_substr($toText, $toSegmentStart, $toSegmentLen), substr($fromText, $fromCopyStart, $copyLen));
 
                         if ($toCopyStart !== false) {
                             $toCopyStart += $toSegmentStart;


### PR DESCRIPTION
Replaced `strpos` with multibyte version.
Updated minimum required php version because of using `mb_str_split`.