### PR TITLE
Make PHP8.1 compatible with ArrayAccess interface

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "type": "library",
     "require": {
-        "php": ">=7.2.0"
+        "php": "~8.1"
     },
     "require-dev": {
         "mockery/mockery": "^1.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,41 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    colors="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    stopOnError="false"
-    stopOnFailure="false"
-    stopOnIncomplete="false"
-    bootstrap="vendor/autoload.php"
->
-    <testsuites>
-        <testsuite name="Delimiters">
-            <directory suffix=".php">tests/Delimiters</directory>
-        </testsuite>
-        <testsuite name="Diff">
-            <directory suffix=".php">tests/Diff</directory>
-        </testsuite>
-        <testsuite name="Granularity">
-            <directory suffix=".php">tests/Granularity</directory>
-        </testsuite>
-        <testsuite name="Parser">
-            <directory suffix=".php">tests/Parser</directory>
-        </testsuite>
-        <testsuite name="Render">
-            <directory suffix=".php">tests/Render</directory>
-        </testsuite>
-        <testsuite name="Usage">
-            <directory suffix=".php">tests/Usage</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-            <exclude>
-                <directory suffix=".php">PEAR_INSTALL_DIR</directory>
-                <directory suffix=".php">PHP_LIBDIR</directory>
-                <directory suffix=".php">vendor</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" colors="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">PEAR_INSTALL_DIR</directory>
+      <directory suffix=".php">PHP_LIBDIR</directory>
+      <directory suffix=".php">vendor</directory>
+    </exclude>
+  </coverage>
+  <testsuites>
+    <testsuite name="Delimiters">
+      <directory suffix=".php">tests/Delimiters</directory>
+    </testsuite>
+    <testsuite name="Diff">
+      <directory suffix=".php">tests/Diff</directory>
+    </testsuite>
+    <testsuite name="Granularity">
+      <directory suffix=".php">tests/Granularity</directory>
+    </testsuite>
+    <testsuite name="Parser">
+      <directory suffix=".php">tests/Parser</directory>
+    </testsuite>
+    <testsuite name="Render">
+      <directory suffix=".php">tests/Render</directory>
+    </testsuite>
+    <testsuite name="Usage">
+      <directory suffix=".php">tests/Usage</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Granularity/Granularity.php
+++ b/src/Granularity/Granularity.php
@@ -7,7 +7,7 @@ trait Granularity
     /**
      * @inheritdoc
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset): bool
     {
         return isset($this->delimiters[$offset]);
     }
@@ -15,15 +15,15 @@ trait Granularity
     /**
      * @inheritdoc
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset): mixed
     {
-        return isset($this->delimiters[$offset]) ? $this->delimiters[$offset] : null;
+        return $this->delimiters[$offset] ?? null;
     }
 
     /**
      * @inheritdoc
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value): void
     {
         if ($offset === null) {
             $this->delimiters[] = $value;
@@ -35,7 +35,7 @@ trait Granularity
     /**
      * @inheritdoc
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset): void
     {
         unset($this->delimiters[$offset]);
     }
@@ -45,7 +45,7 @@ trait Granularity
      *
      * @return int
      */
-    public function count()
+    public function count(): int
     {
         return count($this->delimiters);
     }


### PR DESCRIPTION
Beginning with PHP8.1 a deprecation warning displays if the implemented method signatures do not match what is defined for the `ArrayAccess` interface. This can lead to excessive error log entries. Updated allowed PHP version in the composer.json to 8.1 to prevent PHP <8.1 from being impacted