### PR TITLE
multi-byte safe renderer opcode processing

### DIFF
--- a/src/Render/Renderer.php
+++ b/src/Render/Renderer.php
@@ -28,7 +28,7 @@ abstract class Renderer implements RendererInterface
         $operationCodesOffset = 0;
 
         while ($operationCodesOffset < $operationCodesLen) {
-            $opcode = $operationCodes[$operationCodesOffset];
+            $opcode = mb_substr($operationCodes, $operationCodesOffset, 1);
             $operationCodesOffset++;
             $n = (int) mb_substr($operationCodes, $operationCodesOffset);
 

--- a/tests/Render/Text/ProcessTest.php
+++ b/tests/Render/Text/ProcessTest.php
@@ -49,4 +49,11 @@ class ProcessTest extends TestCase
 
         $this->assertEquals($html, 'Hello2 world');
     }
+
+    public function testProcessMultibyteString()
+    {
+        $html = $this->text->process('Hello worlds', 'c6i2:🐘 c6d');
+
+        $this->assertEquals('Hello 🐘 worlds', $html);
+    }
 }


### PR DESCRIPTION
https://github.com/D4H/php-finediff/issues/7

Now it will be correctly grab opcode from multibyte string(eg with emoji)