### PR TITLE
Fix a deprecation warning triggered in PHP 8.4

### DIFF
--- a/src/Diff.php
+++ b/src/Diff.php
@@ -24,9 +24,9 @@ class Diff
     private $parser;
 
     /**
-     * @param GranularityInterface $granularity
-     * @param RendererInterface $renderer
-     * @param ParserInterface $parser
+     * @param GranularityInterface|null $granularity
+     * @param RendererInterface|null $renderer
+     * @param ParserInterface|null $parser
      */
     public function __construct(
         ?GranularityInterface $granularity = null,

--- a/src/Diff.php
+++ b/src/Diff.php
@@ -29,9 +29,9 @@ class Diff
      * @param ParserInterface $parser
      */
     public function __construct(
-        GranularityInterface $granularity = null,
-        RendererInterface $renderer = null,
-        ParserInterface $parser = null
+        ?GranularityInterface $granularity = null,
+        ?RendererInterface $renderer = null,
+        ?ParserInterface $parser = null
     ) {
         // Set some sensible defaults
         // Set the granularity of the diff


### PR DESCRIPTION
# Fix deprecation warning by adding explicit nullable types in Diff constructor

## Summary
This PR fixes a deprecation warning triggered in PHP 8.4:

```
Deprecated Functionality: FineDiff\Diff::__construct(): Implicitly marking parameter $granularity as nullable is deprecated
```

## Changes
- Updated `FineDiff\Diff::__construct()` to explicitly declare nullable types:
  ```php
  public function __construct(
      ?GranularityInterface $granularity = null,
      ?RendererInterface $renderer = null,
      ?ParserInterface $parser = null
  )


* Ensures compatibility with PHP 8.4 and future versions.

## Why

PHP 8.4 requires explicit nullable type declarations for parameters that have a default `null` value.
This update removes the deprecation warning while keeping full backward compatibility with earlier PHP versions.

## Notes

No functional behavior changes were introduced — this is purely a type declaration update for compatibility.
